### PR TITLE
Add CORS for local development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:latest
+      - image: circleci/node:8-stretch-browsers
       - image: circleci/mongo:3.4.4
 
     working_directory: ~/repo

--- a/app.js
+++ b/app.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const NODE_ENV = process.env.NODE_ENV || 'development';
 const statuses = require('statuses');
 statuses[420] = 'Increase your chill';
 
 const Koa = require('koa');
+const cors = require('koa2-cors');
 const app = new Koa();
 
 const {logger, middleware} = require('./lib/logger')();
@@ -12,6 +14,14 @@ const catchErrors = require('./lib/catch_errors')(logger);
 app.use(middleware);
 
 app.use(catchErrors);
+
+if(NODE_ENV !== 'production') app.use(cors({
+	maxAge: 7 * 24 * 60 * 60, 
+	origin: '*',
+	authentication: true,
+	allowMethods: ['GET', 'POST', 'OPTIONS', 'DELETE'], 
+	allowHeaders: ['Content-Type', 'Authorization', 'Accept']
+}));
 
 const router = require('./routes/router.js')(logger);
 app.use(router.routes());

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -248,6 +257,11 @@
         "depd": "1.1.1",
         "keygrip": "1.0.2"
       }
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -911,6 +925,14 @@
             "any-promise": "1.3.0"
           }
         }
+      }
+    },
+    "koa2-cors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/koa2-cors/-/koa2-cors-2.0.4.tgz",
+      "integrity": "sha1-b7wznj9st8I2UT0cpk6bBat+GQA=",
+      "requires": {
+        "babel-runtime": "6.26.0"
       }
     },
     "lcov-parse": {
@@ -2998,6 +3020,11 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
     "request": {
       "version": "2.83.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "koa": "^2.3.0",
     "koa-body": "^2.3.0",
     "koa-router": "^7.2.1",
+    "koa2-cors": "^2.0.4",
     "lodash": "^4.17.4",
     "mongodb": "^2.2.31",
     "strong-params": "^0.7.1"


### PR DESCRIPTION
Adds koa2-cors gem and basic config for local development
Production environments are expected to handle CORS on their own
Update circle config to use a specific version of node